### PR TITLE
usePCAVarianceRatio

### DIFF
--- a/PCA.py
+++ b/PCA.py
@@ -34,7 +34,7 @@ class PCA(object):
         global loadings
         loadings = pca.components_
         varianceArray = pca.explained_variance_ratio_
-        PCA.componentVariance = pca.explained_variance_
+        PCA.componentVariance = pca.explained_variance_ratio_
         temprange = range(1,(len(varianceArray)-1))
         maxDerivative = 0
         secondDerivative =[]

--- a/PCAGraph.py
+++ b/PCAGraph.py
@@ -50,8 +50,9 @@ class PCAGraph(FigureCanvas):
         
             #if forReport:
             #    ax.annotate(element, xy=(PCA.plotdata[outlierIndex[1], 0],  PCA.plotdata[outlierIndex[1], 1]),color='green')
-        ax.set_xlabel("PC1   "+ str(round(PCA.PCA.componentVariance[0],4))+ "%")
-        ax.set_ylabel("PC2   "+ str(round(PCA.PCA.componentVariance[1],4))+ "%")
+        ax.set_xlabel("PC1   "+ str(round(PCA.PCA.componentVariance[0]*100,4))+ "%")
+        print(PCA.PCA.componentVariance)
+        ax.set_ylabel("PC2   "+ str(round(PCA.PCA.componentVariance[1]*100,4))+ "%")
         FigureCanvas.__init__(self, fig)
         #self.setParent(parent)
 


### PR DESCRIPTION
Previously, the property explained_variance_ was reported, which contains the eigenvalue rather than explained_variance_ratio_ which contains the proportion variance explained.